### PR TITLE
Highlight last program-change pad for each preset

### DIFF
--- a/lib/screen_beat_pads/beat_pad.dart
+++ b/lib/screen_beat_pads/beat_pad.dart
@@ -37,29 +37,46 @@ class SlideBeatPadState extends ConsumerState<SlideBeatPad> {
       sustainedVelocity = 0;
     }
 
-    final Color color = ref.watch(layoutProv) == Layout.progrChange
+    final bool isProgChange = ref.watch(layoutProv) == Layout.progrChange;
+
+    // Read per-preset last program-change pads and current preset index.
+    final List<int?> lastPads = ref.watch(lastProgramChangePadsProv);
+    final int currentPreset = ref.watch(presetNotifierProvider);
+    int lastProgForPreset;
+
+    int? lastProg;
+    final int idx = currentPreset - PresetNotfier.basePreset;
+    if (idx >= 0 && idx < lastPads.length) {
+      lastProg = lastPads[idx];
+    } else {
+      lastProg = null;
+    }
+
+    final Color color = isProgChange
         ? ref
-              .watch(padColorsProv)
-              .colorize(
-                Scale.chromatic.intervals,
-                ref.watch(baseHueProv),
-                ref.watch(rootProv),
-                note,
-                0, // no Rx Midi with PROG Change
-                noteOn: false, // no NoteOn with PROG Change
-              )
+            .watch(padColorsProv)
+            .colorize(
+              Scale.chromatic.intervals,
+              ref.watch(baseHueProv),
+              ref.watch(rootProv),
+              note,
+              // If this pad was the last program-change pad for this preset,
+              // give it a high receivedVelocity so pad_colors returns a visible highlight.
+              lastProg != null && lastProg == note ? 127 : 0,
+              noteOn: lastProg != null && lastProg == note,
+            )
         : ref
-              .watch(padColorsProv)
-              .colorize(
-                ref.watch(scaleProv).intervals,
-                ref.watch(baseHueProv),
-                ref.watch(rootProv),
-                note,
-                widget.preview ? 0 : ref.watch(rxNoteProvider)[note],
-                noteOn: sustainState
-                    ? sustainedVelocity > 0
-                    : playedVelocity > 0,
-              );
+            .watch(padColorsProv)
+            .colorize(
+              ref.watch(scaleProv).intervals,
+              ref.watch(baseHueProv),
+              ref.watch(rootProv),
+              note,
+              widget.preview ? 0 : ref.watch(rxNoteProvider)[note],
+              noteOn: sustainState
+                  ? sustainedVelocity > 0
+                  : playedVelocity > 0,
+            );
 
     final Label label = PadLabels.getLabel(
       note: note,

--- a/lib/services/state/midi_send.dart
+++ b/lib/services/state/midi_send.dart
@@ -91,12 +91,13 @@ final combinedSettings = Provider.autoDispose<SendSettings>((ref) {
 
 /// The usable sender object, which refreshes when any relevant setting changes
 final senderProvider = ChangeNotifierProvider.autoDispose<MidiSender>((ref) {
-  return MidiSender(ref.watch(combinedSettings));
+  // Pass ref so MidiSender can update providers (e.g., last program-change per preset)
+  return MidiSender(ref, ref.watch(combinedSettings));
 });
 
 class MidiSender extends ChangeNotifier {
   /// Handles Touches and Midi Message sending
-  MidiSender(this.settings) {
+  MidiSender(this._ref, this.settings) {
     playModeHandler = settings.playMode
         .getPlayModeApi(settings, _notifyListenersOfMidiSender);
 
@@ -107,6 +108,8 @@ class MidiSender extends ChangeNotifier {
       ).send();
     }
   }
+
+  final Ref _ref;
   late PlayModeHandler playModeHandler;
   final SendSettings settings;
 
@@ -145,8 +148,21 @@ class MidiSender extends ChangeNotifier {
     if (settings.layout != Layout.progrChange) {
       playModeHandler.handleNewTouch(data);
     } else {
-      PCMessage(channel: settings.channel, program: data.customPad.padValue)
-          .send();
+      final int padValue = data.customPad.padValue;
+      PCMessage(channel: settings.channel, program: padValue).send();
+
+      // Remember the last program-change pad for the current preset so the UI can highlight it.
+      try {
+        final int currentPreset = _ref.read(presetNotifierProvider);
+        final pads = List<int?>.from(_ref.read(lastProgramChangePadsProv));
+        int index = currentPreset - PresetNotfier.basePreset;
+        if (index < 0) index = 0;
+        if (index >= PresetNotfier.numberOfPresets) index = PresetNotfier.numberOfPresets - 1;
+        pads[index] = padValue;
+        _ref.read(lastProgramChangePadsProv.notifier).state = pads;
+      } catch (_) {
+        // If the provider isn't available for some reason, ignore.
+      }
     }
   }
 

--- a/lib/services/state/settings_midi.dart
+++ b/lib/services/state/settings_midi.dart
@@ -79,3 +79,16 @@ final velocityRangeProv = Provider<int>((ref) {
 final velocityCenterProv = Provider<double>((ref) {
   return (ref.watch(velocityMaxProv) + ref.watch(velocityMinProv)) / 2;
 });
+
+/// Holds the last pressed pad value for each preset when in Program Change
+/// layout. Index 0 corresponds to preset 1. This is used to visually
+/// highlight the last program-change selection per-preset on the grid.
+final lastProgramChangePadsProv = StateProvider<List<int?>>((ref) {
+  // Initialize with nulls for each preset.
+  return List<int?>.filled(
+    PresetNotfier.numberOfPresets,
+    null,
+    growable: false,
+  );
+});
+


### PR DESCRIPTION
This pull request updates the functionality of the beat pad application to remember the last pressed pad for each of the five presets in "program change" mode. 

### Changes made:
- **State Management**:
  - Replaced the single `lastProgramChangePadProv` with a list provider `lastProgramChangePadsProv` in `lib/services/state/settings_midi.dart` to store the last program change for each preset.
  
- **MIDI Sending Logic**:
  - Updated `senderProvider` to pass the reference into `MidiSender` and modified it to store the last program change for each preset in `lib/services/state/midi_send.dart`.

- **UI Updates**:
  - Modified `lib/screen_beat_pads/beat_pad.dart` to read from the per-preset last program change and highlight the corresponding pad accordingly.

### How it works:
- When a pad is tapped in the Program Change layout, the app sends a PCMessage and updates the respective index in `lastProgramChangePadsProv` based on the selected preset.
- The pad rendering logic checks the `lastProgramChangePadsProv` for the current preset and highlights the corresponding pad with an emphasized color.

### Verification steps:
1. Run the app.
2. Select the "Program Changes" layout.
3. Tap a pad for each of the five presets — the tapped pad should remain visibly highlighted until another pad is tapped or the layout changes.

This implementation enhances user experience by providing clear visual feedback on the last interacted pad for each preset.